### PR TITLE
Add tasks for applying one-off patches to 12.1 SI instances

### DIFF
--- a/tasks/si_asm.12.1.0.2.yml
+++ b/tasks/si_asm.12.1.0.2.yml
@@ -6,3 +6,46 @@
   register: dbbp_opatchauto
 
 - debug: var=dbbp_opatchauto.stdout_lines
+
+- name: srvctl stop home
+  shell: "{{ oracle_home }}/bin/srvctl stop home -o {{ oracle_home }} -s {{ patch_directory }}/12c_srvctl.state -f"
+  environment: "{{ env }}"
+  become_user: "{{ oracle_user }}"
+
+- name: Template patch list
+  template:
+    src: patch_list.j2
+    dest: "{{ patch_directory }}/patch_list.txt"
+    owner: "{{ oracle_user }}"
+    group: "{{ oracle_group }}"
+  when: patch_level[oracle_version].oneoff_patches is defined
+
+- name: Opatch prereq check for oneoff patches
+  shell: opatch prereq CheckConflictAgainstOHWithDetail -phBaseFile {{ patch_directory }}/patch_list.txt
+  environment: "{{ env }}"
+  become_user: "{{ oracle_user }}"
+  register: oneoff_conflicts_psu
+  when: patch_level[oracle_version].oneoff_patches is defined
+
+- debug: var=oneoff_conflicts_psu.stdout_lines
+  when: patch_level[oracle_version].oneoff_patches is defined
+
+- name: Apply one-off patches
+  shell: opatch napply -silent -phBaseFile {{ patch_directory }}/patch_list.txt
+  environment: "{{ env }}"
+  become_user: "{{ oracle_user }}"
+  register: oneoff_apply_psu
+  when: patch_level[oracle_version].oneoff_patches is defined
+
+- debug: var=oneoff_apply_psu.stdout_lines
+  when: patch_level[oracle_version].oneoff_patches is defined
+
+- name: srvctl start home
+  shell: "{{ oracle_home }}/bin/srvctl start home -o {{ oracle_home }} -s {{ patch_directory }}/12c_srvctl.state"
+  environment: "{{ env }}"
+  become_user: "{{ oracle_user }}"
+
+- name: remove state file
+  file:
+    path: "{{ patch_directory }}/12c_srvctl.state"
+    state: absent


### PR DESCRIPTION
Used these tasks for applying one-off patches to 12.1 home on sldataw and pldataw.